### PR TITLE
docs: 修复《可视化 Rust 各数据类型的内存布局》里面拼写错误

### DIFF
--- a/Articles/[2022-05-04] 可视化 Rust 各数据类型的内存布局.md
+++ b/Articles/[2022-05-04] 可视化 Rust 各数据类型的内存布局.md
@@ -770,7 +770,7 @@ Rc 在堆上的地址。
 <img src="https://gitee.com/rustcn/rustt-assets/raw/main/20220504-Visualizing-memory-layout-of-Rust-data-types/202205041812961.png?raw=true" height=400px />
 
 现在你能通过克隆 v 来创建 v2，这个克隆不会克隆任何位于堆上的数据，他只会克隆一份栈上的地址，然后将 Rc 的引用计数加 1，现在 v 和 v2
-都持有相同的一份数据，这就是为什么它被称为引用技术指针。
+都持有相同的一份数据，这就是为什么它被称为引用计数指针。
 
 <img src="https://gitee.com/rustcn/rustt-assets/raw/main/20220504-Visualizing-memory-layout-of-Rust-data-types/202205041814163.png?raw=true" height=400px />
 
@@ -816,7 +816,7 @@ let data: Arc<Mutex<i32>> = Arc::new(Mutex::new(0));
 ```rust
 use std::io::Write;
 
-let mur buffer: Vec<u8> = vec![];
+let mut buffer: Vec<u8> = vec![];
 let w: &mut dyn Write = &mut buffer;
 ```
 


### PR DESCRIPTION
修复文章里面的拼写错误